### PR TITLE
Make translation and compilation environments mutable

### DIFF
--- a/src/bin/dune
+++ b/src/bin/dune
@@ -3,4 +3,5 @@
   (libraries
      ir cmmcompile util libwasm getopt
      compiler-libs.optcomp bigarray str)
+  ;; (ocamlopt_flags :standard -p )
 )

--- a/src/lib/cmmcompile/compile_env.ml
+++ b/src/lib/cmmcompile/compile_env.ml
@@ -1,16 +1,16 @@
 type t = {
-  var_env : Ident.t Ir.Var.Map.t;
-  label_env : int Ir.Label.Id.Map.t;
-  label_count : int;
+  var_env : (Ir.Var.t, Ident.t) Hashtbl.t;
+  label_env : (Ir.Label.Id.t, int) Hashtbl.t;
+  mutable label_count : int;
   module_name : string;
   memory: Ir.Stackless.memory option;
   table : Ir.Stackless.table option;
   imported_function_count: int
 }
 
-let empty ~module_name ~memory ~table ~imported_function_count = {
-  var_env = Ir.Var.Map.empty;
-  label_env = Ir.Label.Id.Map.empty;
+let create ~module_name ~memory ~table ~imported_function_count = {
+  var_env = Hashtbl.create 100;
+  label_env = Hashtbl.create 20;
   label_count = 0;
   module_name;
   memory;
@@ -20,20 +20,18 @@ let empty ~module_name ~memory ~table ~imported_function_count = {
 
 let module_name env = env.module_name
 
-let bind_var v i env = {
-  env with var_env = Ir.Var.Map.add v i env.var_env
-}
+let bind_var v i env = Hashtbl.replace env.var_env v i
 
-let lookup_var v env = Ir.Var.Map.find v env.var_env
+let lookup_var v env = Hashtbl.find env.var_env v
 
 let bind_label lbl env =
   let lbl_id = env.label_count in
-  (lbl_id,
-    { env with
-      label_count = lbl_id + 1;
-      label_env = Ir.Label.Id.Map.add (Ir.Label.id lbl) lbl_id env.label_env })
+  env.label_count <- env.label_count + 1;
+  Hashtbl.replace env.label_env (Ir.Label.id lbl) lbl_id;
+  lbl_id
 
-let lookup_label lbl env = Ir.Label.Id.Map.find (Ir.Label.id lbl) env.label_env
+let lookup_label lbl env =
+  Hashtbl.find env.label_env (Ir.Label.id lbl)
 
 let func_symbol func env =
   Ir.Func.symbol ~module_name:env.module_name func
@@ -54,7 +52,7 @@ let memory_symbol env =
     | _ -> env.module_name ^ "_internalmemory"
 
 let imported_function_count env = env.imported_function_count
-
+(*
 let dump env =
   let open Ir in
 
@@ -80,3 +78,5 @@ let dump env =
   print_label_env ();
   Printf.printf "Label count: %d\n" env.label_count
 
+  *)
+let dump _ = ()

--- a/src/lib/cmmcompile/compile_env.ml
+++ b/src/lib/cmmcompile/compile_env.ml
@@ -52,31 +52,4 @@ let memory_symbol env =
     | _ -> env.module_name ^ "_internalmemory"
 
 let imported_function_count env = env.imported_function_count
-(*
-let dump env =
-  let open Ir in
 
-  let print_var_env () =
-    let bindings = Var.Map.bindings (env.var_env) in
-    List.iter (fun (k, v) ->
-      Printf.printf "%s : %s"
-        (Var.to_string k)
-    (Ident.unique_name v)) bindings;
-    print_newline () in
-
-  let print_label_env () =
-    let bindings = Label.Id.Map.bindings (env.label_env) in
-    List.iter (fun (k, v) ->
-      Label.Id.print Format.str_formatter k;
-      Printf.printf "%s : %d\n"
-        (Format.flush_str_formatter ()) v) bindings;
-      print_newline () in
-
-  print_endline "Var env:";
-  print_var_env ();
-  print_endline "Label env:";
-  print_label_env ();
-  Printf.printf "Label count: %d\n" env.label_count
-
-  *)
-let dump _ = ()

--- a/src/lib/cmmcompile/compile_env.mli
+++ b/src/lib/cmmcompile/compile_env.mli
@@ -1,15 +1,15 @@
 type t
 
-val empty :
+val create :
   module_name:string ->
   memory:Ir.Stackless.memory option ->
   table:Ir.Stackless.table option ->
   imported_function_count:int ->
   t
 
-val bind_var : Ir.Var.t -> Ident.t -> t -> t
+val bind_var : Ir.Var.t -> Ident.t -> t -> unit
 val lookup_var : Ir.Var.t -> t -> Ident.t
-val bind_label : Ir.Label.t -> t -> (int * t)
+val bind_label : Ir.Label.t -> t -> int
 val lookup_label : Ir.Label.t -> t -> int
 val module_name : t -> string
 val dump : t -> unit

--- a/src/lib/cmmcompile/compile_env.mli
+++ b/src/lib/cmmcompile/compile_env.mli
@@ -12,7 +12,6 @@ val lookup_var : Ir.Var.t -> t -> Ident.t
 val bind_label : Ir.Label.t -> t -> int
 val lookup_label : Ir.Label.t -> t -> int
 val module_name : t -> string
-val dump : t -> unit
 
 val imported_function_count : t -> int
 

--- a/src/lib/ir/translate_env.ml
+++ b/src/lib/ir/translate_env.ml
@@ -114,6 +114,7 @@ let dump_stack env =
   |> print_endline
 
 let locals env = Array.to_list env.locals
+
 let set_locals locals env =
   env.locals <- (Array.of_list locals)
 

--- a/src/lib/ir/translate_env.ml
+++ b/src/lib/ir/translate_env.ml
@@ -1,99 +1,128 @@
 open Util.Maps
 
 type t = {
-  stack : Var.t list;
-  block_continuation: Label.t;
-  function_return: Label.t;
-  locals: Var.t Int32Map.t;
-  labels: Label.t list;
-  globals: Global.t Int32Map.t;
-  functions: Func.t Int32Map.t;
-  types: Libwasm.Types.func_type Int32Map.t
+  mutable stack : Var.t list;
+  mutable block_continuation: Label.t;
+  mutable function_return: Label.t;
+  mutable locals: Var.t array;
+  mutable labels: Label.t list;
+  globals: Global.t array;
+  functions: Func.t array;
+  types: Libwasm.Types.func_type array
 }
 
 let create ~stack ~continuation ~return ~locals ~globals ~functions ~types =
+  (* Assumes a dense ordering -- which we are guaranteed to have by
+   * OCaml's indexing system *)
+  let array_of_map m =
+    let max_key =
+      match Int32Map.max_binding_opt m with
+        | Some (k, _) -> (Int32.to_int k) + 1
+        | None -> 0 in
+    Array.init max_key (fun k -> Int32Map.find (Int32.of_int k) m) in
+  let locals_arr = array_of_map locals in
   {
   stack;
   block_continuation = continuation;
   function_return = return;
   labels = [continuation];
-  locals;
-  globals;
-  functions;
-  types
+  locals = locals_arr;
+  globals = array_of_map globals;
+  functions = array_of_map functions;
+  types = array_of_map types
 }
+
+let copy env =
+  let locals_copy = Array.copy env.locals in
+  (* Globals, functions, and types do not change throughout execution,
+   * so there is no need to copy them. *)
+  { env with locals = locals_copy }
 
 let continuation env = env.block_continuation
 let return env = env.function_return
 let stack env = env.stack
-let with_continuation lbl env =
-  { env with block_continuation = lbl }
+let set_continuation lbl env =
+  env.block_continuation <- lbl
 
 let push_label lbl env =
-  { env with labels = lbl :: env.labels }
-
-let set_local (var: Libwasm.Ast.var) value env =
-  { env with locals = Int32Map.add (var.it) value (env.locals) }
-
-let get_local (var: Libwasm.Ast.var) env =
-  Int32Map.find (var.it) env.locals
-
-let push x env = { env with stack = x :: (env.stack) }
-
-let pop env =
-  match env.stack with
-    | [] -> failwith "FATAL (pop): Tried to pop from empty virtual stack"
-    | x :: xs -> (x, { env with stack = xs })
-
-let pop2 env =
-  match env.stack with
-    | x :: y :: xs -> ((x, y), { env with stack = xs })
-    | _ -> failwith "FATAL (pop2): Tried to pop from empty virtual stack"
+  env.labels <- lbl :: env.labels
 
 let nth_label (depth_var: Libwasm.Ast.var) env =
-  List.nth env.labels (Int32.to_int depth_var.it) 
+  List.nth env.labels (Int32.to_int depth_var.it)
 
-let popn n env =
-  (* Printf.printf "popn n = %d, height = %d\n" n (List.length env.stack); *)
+let set_local (var: Libwasm.Ast.var) value env =
+  env.locals.(Int32.to_int var.it) <- value
+
+let get_local (var: Libwasm.Ast.var) env =
+  env.locals.(Int32.to_int var.it)
+
+let push x env =
+  env.stack <- (x :: (env.stack))
+
+
+let split_stack stack count =
   let rec go n xs =
     if n = 0 then ([], xs) else
       match xs with
-        | [] -> failwith "FATAL (popn): Tried to pop from empty virtual stack"
+        | [] -> failwith "FATAL (split_stack): Tried to pop from empty virtual stack"
         | x :: xs ->
             let (returned, rest) = go (n - 1) xs in
             (x :: returned, rest) in
-  let (popped, rest) = go n env.stack in
-  popped, { env with stack = rest }
+  go count stack
+
+let peek env =
+  let [@warning "-8"] ([x], _) = split_stack env.stack 1 in
+  x
+
+let peek2 env =
+  let [@warning "-8"] ([x; y], _) = split_stack env.stack 2 in
+  (x, y)
+
+let peekn n env =
+  let (xs, _) = split_stack env.stack n in
+  xs
+
+let peekn_rev n env =
+  let (xs, _) = split_stack env.stack n in
+  List.rev xs
+
+let pop env =
+  let [@warning "-8"] ([x], rest) = split_stack env.stack 1 in
+  env.stack <- rest;
+  x
+
+let pop2 env =
+  let [@warning "-8"] ([x; y], rest) = split_stack env.stack 2 in
+  env.stack <- rest;
+  (x, y)
+
+let popn n env =
+  let (xs, rest) = split_stack env.stack n in
+  env.stack <- rest;
+  xs
 
 let popn_rev n env =
-  let (args_rev, env) = popn n env in
-  (List.rev args_rev, env)
+  let (xs, rest) = split_stack env.stack n in
+  env.stack <- rest;
+  List.rev xs
 
-let with_stack stack env = { env with stack }
-
+let set_stack stack env = env.stack <- stack
 
 let dump_stack env =
   List.map (Var.to_string) env.stack
   |> String.concat " :: "
   |> print_endline
 
-let locals env =
-  Int32Map.bindings env.locals
-  |> List.map snd
-
-let with_locals locals env =
-  let (_, new_locals) =
-  List.fold_left (fun (i, acc) v ->
-    let acc = Int32Map.add i v acc in
-    (Int32.(add i one), acc)
-  ) (Int32.zero, Int32Map.empty) locals in
-  { env with locals = new_locals}
+let locals env = Array.to_list env.locals
+let set_locals locals env =
+  env.locals <- (Array.of_list locals)
 
 let get_global (var: Libwasm.Ast.var) env =
-  Int32Map.find (var.it) env.globals
+  env.globals.(Int32.to_int var.it)
 
 let get_function (var: Libwasm.Ast.var) env =
-  Int32Map.find (var.it) env.functions
+  env.functions.(Int32.to_int var.it)
 
 let get_type (var: Libwasm.Ast.var) env =
-  Int32Map.find (var.it) env.types
+  env.types.(Int32.to_int var.it)
+

--- a/src/lib/ir/translate_env.mli
+++ b/src/lib/ir/translate_env.mli
@@ -13,30 +13,37 @@ val create :
 val continuation : t -> Label.t
 val return : t -> Label.t
 
+(* Creates a fresh copy of the environment *)
+val copy : t -> t
+
 (* Virtual stack *)
 val stack : t -> Var.t list
-val push : Var.t -> t -> t
-val pop : t -> (Var.t * t)
-val pop2 : t -> ((Var.t * Var.t) * t)
-val popn : int -> t -> (Var.t list * t)
-val popn_rev : int -> t -> (Var.t list * t)
-val with_stack : Var.t list -> t -> t
+val push : Var.t -> t -> unit
+val pop : t -> Var.t
+val pop2 : t -> (Var.t * Var.t)
+val popn : int -> t -> Var.t list
+val popn_rev : int -> t -> Var.t list
+val peek : t -> Var.t
+val peek2 : t -> (Var.t * Var.t)
+val peekn : int -> t -> Var.t list
+val peekn_rev : int -> t -> Var.t list
+val set_stack : Var.t list -> t -> unit
 
 (* Control stack *)
-val push_label : Label.t -> t -> t
+val push_label : Label.t -> t -> unit
 val nth_label : Libwasm.Ast.var -> t -> Label.t
 (* Local variable store *)
-val set_local : Libwasm.Ast.var -> Var.t -> t -> t
+val set_local : Libwasm.Ast.var -> Var.t -> t -> unit
 val get_local : Libwasm.Ast.var -> t -> Var.t
 val locals : t -> Var.t list
-val with_locals : Var.t list -> t -> t
+val set_locals : Var.t list -> t -> unit
 
 (* Globals *)
 val get_global : Libwasm.Ast.var -> t -> Global.t
 
 (* Functions *)
 val get_function : Libwasm.Ast.var -> t -> Func.t
-val with_continuation : Label.t -> t -> t
+val set_continuation : Label.t -> t -> unit
 
 (* Types *)
 val get_type : Libwasm.Ast.var -> t -> Libwasm.Types.func_type


### PR DESCRIPTION
This makes the translation and compilation environments mutable, as I've been meaning to do for a while. It modestly speeds up CMM generation. The main bottleneck now seems to be in the OCaml compiler generating ASM from the generated CMM.