### PR TITLE
Default to linear scan allocator.

### DIFF
--- a/includes/spec-wasm2c-prefix.c
+++ b/includes/spec-wasm2c-prefix.c
@@ -60,8 +60,9 @@ static void error(const char* file, int line, const char* format, ...) {
 #define ASSERT_RETURN(f)                           \
   do {                                             \
     g_tests_run++;                                 \
-    if (wasm_rt_impl_try() != 0) {                 \
-      error(__FILE__, __LINE__, #f " trapped.\n"); \
+    int res = wasm_rt_impl_try();                  \
+    if (res)                     {                 \
+      error(__FILE__, __LINE__, #f " trapped (%d).\n", res); \
     } else {                                       \
       f;                                           \
       g_tests_passed++;                            \
@@ -71,8 +72,9 @@ static void error(const char* file, int line, const char* format, ...) {
 #define ASSERT_RETURN_T(type, fmt, f, expected)                          \
   do {                                                                   \
     g_tests_run++;                                                       \
-    if (wasm_rt_impl_try() != 0) {                                       \
-      error(__FILE__, __LINE__, #f " trapped.\n");                       \
+    int res = wasm_rt_impl_try();                  \
+    if (res)                     {                 \
+      error(__FILE__, __LINE__, #f " trapped (%d).\n", res); \
     } else {                                                             \
       type actual = f;                                                   \
       if (is_equal_##type(actual, expected)) {                           \

--- a/src/bin/build_utils.ml
+++ b/src/bin/build_utils.ml
@@ -5,6 +5,7 @@ open Util.Trace
 
 let gen_asm out name cmm =
   Clflags.dump_linear := Command_line.dump_linear ();
+  Clflags.use_linscan := (not (Command_line.colouring_allocator ()));
   Emitaux.create_asm_file := true;
   Emitaux.output_channel := open_out out;
   Compilenv.reset ?packname:None name;

--- a/src/lib/cmmcompile/cmm_rts.ml
+++ b/src/lib/cmmcompile/cmm_rts.ml
@@ -9,10 +9,6 @@ type cmm_address = Cmm.expression
 
 
 module Memory = struct
-  (* We may need to do some intermediate bindings -- in order to stop
-   * this blowing up the register allocator, we can just create the single
-   * identifier and use that, since they won't be live at the same time *)
-  let eo_ident = Ident.create "eo_ident"
 
   let nodbg = Debuginfo.none
   let i64_to_native = Int64.to_nativeint
@@ -137,6 +133,7 @@ module Memory = struct
     let static_offset = Nativeint.of_int32 op.offset in
     let chunk = chunk_of_loadop op in
     let eo = effective_offset dynamic_pointer static_offset in
+    let eo_ident = Ident.create "eo_ident" in
     let eo_var = Cvar eo_ident in
 
     let expr eo =
@@ -168,6 +165,7 @@ module Memory = struct
     let static_offset = Nativeint.of_int32 op.offset in
     let chunk = chunk_of_storeop op in
     let eo = effective_offset dynamic_pointer static_offset in
+    let eo_ident = Ident.create "eo_ident" in
     let eo_var = Cvar eo_ident in
     (* As above. *)
     let expr eo =

--- a/src/lib/cmmcompile/compile_env.ml
+++ b/src/lib/cmmcompile/compile_env.ml
@@ -6,10 +6,10 @@ type t = {
   module_name : string;
   memory: Ir.Stackless.memory option;
   table : Ir.Stackless.table option;
-  imported_function_count: int
+  mutable fuel_ident: Ident.t
 }
 
-let create ~module_name ~memory ~table ~imported_function_count = {
+let create ~module_name ~memory ~table = {
   var_env = Hashtbl.create 200;
   label_env = Hashtbl.create 100;
   const_env = Hashtbl.create 200;
@@ -17,8 +17,15 @@ let create ~module_name ~memory ~table ~imported_function_count = {
   module_name;
   memory;
   table;
-  imported_function_count
+  fuel_ident = Ident.create "fuel"
 }
+
+let reset env =
+  Hashtbl.reset env.var_env;
+  Hashtbl.reset env.label_env;
+  Hashtbl.reset env.const_env;
+  env.label_count <- 0;
+  env.fuel_ident <- Ident.create "fuel"
 
 let module_name env = env.module_name
 
@@ -53,9 +60,9 @@ let memory_symbol env =
         Printf.sprintf "%s_memory_%s" module_name memory_name
     | _ -> env.module_name ^ "_internalmemory"
 
-let imported_function_count env = env.imported_function_count
-
 let add_constant var const env = Hashtbl.replace env.const_env var const
+
+let fuel_ident env = env.fuel_ident
 
 (* Tries to resolve a constant. If it's in the constant environment,
  * then returns the cached constant. *)

--- a/src/lib/cmmcompile/compile_env.mli
+++ b/src/lib/cmmcompile/compile_env.mli
@@ -4,7 +4,6 @@ val create :
   module_name:string ->
   memory:Ir.Stackless.memory option ->
   table:Ir.Stackless.table option ->
-  imported_function_count:int ->
   t
 
 val bind_var : Ir.Var.t -> Ident.t -> t -> unit
@@ -13,8 +12,6 @@ val bind_label : Ir.Label.t -> t -> int
 val lookup_label : Ir.Label.t -> t -> int
 val module_name : t -> string
 
-val imported_function_count : t -> int
-
 val memory_symbol : t -> string
 val table_symbol : t -> string
 val func_symbol : Ir.Func.t -> t -> string
@@ -22,3 +19,6 @@ val global_symbol : Ir.Global.t -> t -> string
 
 val add_constant : Ir.Var.t -> Cmm.expression -> t -> unit
 val resolve_variable : Ir.Var.t -> t -> Cmm.expression
+
+val fuel_ident : t -> Ident.t
+val reset : t -> unit

--- a/src/lib/ir/genstackless.ml
+++ b/src/lib/ir/genstackless.ml
@@ -545,7 +545,6 @@ let ir_module (ast_mod: Annotated.module_) =
 
     (* And for now, that should be it? *)
     { function_metadata = func_metadata_map;
-      imported_function_count = Int32.to_int func_import_count;
       function_ir;
       globals;
       start;

--- a/src/lib/ir/stackless.ml
+++ b/src/lib/ir/stackless.ml
@@ -76,7 +76,6 @@ type memory =
 
 type module_ = {
     function_metadata : Func.t Util.Maps.Int32Map.t;
-    imported_function_count: int;
     (* Note that function_ir only contains entries for defined
      * (not imported) functions *)
     function_ir: func Util.Maps.Int32Map.t;

--- a/src/lib/util/command_line.ml
+++ b/src/lib/util/command_line.ml
@@ -14,6 +14,7 @@ module Refs = struct
   let initial_fuel = ref 500
   let keep_temp = ref false
   let prefix = ref None
+  let colouring_allocator = ref false
 end
 
 let options =
@@ -30,7 +31,8 @@ let options =
     (noshort, "header-prefix", None, Some (fun s -> Refs.header_prefix_path := (Some s)));
     (noshort, "fuel", None, Some (fun i -> Refs.initial_fuel := (int_of_string i)));
     ('t', "keep-temp", Some (fun () -> Refs.keep_temp := true), None);
-    ('p', "prefix", None, Some (fun s -> Refs.prefix := (Some s)))
+    ('p', "prefix", None, Some (fun s -> Refs.prefix := (Some s)));
+    (noshort, "colouring", Some (fun () -> Refs.colouring_allocator := true), None)
   ]
 
 let set_filename fn = Refs.filename := fn
@@ -94,3 +96,5 @@ let initial_fuel () = !Refs.initial_fuel
 let keep_temp () = !Refs.keep_temp
 
 let prefix () = !Refs.prefix
+
+let colouring_allocator () = !Refs.colouring_allocator

--- a/src/lib/util/command_line.mli
+++ b/src/lib/util/command_line.mli
@@ -14,3 +14,4 @@ val rts_header : unit -> string
 val initial_fuel : unit -> int
 val keep_temp : unit -> bool
 val prefix : unit -> string option
+val colouring_allocator : unit -> bool


### PR DESCRIPTION
Even though we're pruning as many redundant let-bindings as possible through the use of constant folding, DCE, and inlining, we still have too many in certain circumstances, which leads to huge compile times using the default OCaml allocator.

In this patch, we default to the linear scan allocator (allowing use of the colouring allocator through a compile flag). This allows the game demo to compile in less than a minute (which is still pretty high, but tractable), reduces `skip-stack-guard-page` to ~8seconds, and shaves a minute off the test suite runtime.

The patch also fixes a bug where the fuel variable is not propagated over an exported call (d'oh!). This in turn fixes #62.

I imagine we can speed things up even more when we end up optimising memory checks.