### PR TITLE
Emscripten RTS

### DIFF
--- a/src/bin/c_stubs.ml
+++ b/src/bin/c_stubs.ml
@@ -273,6 +273,9 @@ let header ~prefix ~exports =
             Printf.sprintf "%s* %s;" (string_of_ctype type_) name
     ) exports
     |> String.concat "\n" in
+  let init_stub_header = Printf.sprintf "void %s_init();\n" prefix in
+  let header_exports = init_stub_header ^ header_exports in
+
 
   let header_name =
     Printf.sprintf "__CMMOFWASM_%s_H" (String.uppercase_ascii prefix) in

--- a/src/lib/cmmcompile/gencmm.ml
+++ b/src/lib/cmmcompile/gencmm.ml
@@ -761,10 +761,9 @@ let compile_expression env =
               (* If it's immutable, we may simply return its (compiled) initial
                * value. *)
               compile_value v
-          | DefinedGlobal { initial_value = AnotherGlobal g ; _ } ->
-              (* If we're referencing another global, then we know by
-               * the specification that the other global *must* be an
-               * imported global. *)
+          | DefinedGlobal _ ->
+              (* If it's been initialised from another global, we need
+               * to do a load. *)
               load_global g
           | ImportedGlobal _ ->
               (* If we're referencing an imported global, we load that. *)

--- a/src/rts/emscripten_rts.c
+++ b/src/rts/emscripten_rts.c
@@ -1,13 +1,155 @@
 #include "emscripten_rts.h"
+// Syscall stuff
 
-void err(char** str) {
+// Variadic arguments scaffolding
+uint64_t varargs_position = 0;
+
+uint32_t heap_read_int32(uint32_t ptr) {
+  // NOTE: I'm not entirely sure what the >>2 in the
+  // generated JS is all about. My guess is that it's an
+  // artefact of the array encoding, so I'm ignoring it for
+  // now.
+  uint8_t* heap_base = env_memory_memory.data;
+  uint32_t ret = *((uint32_t*)(heap_base + ptr));
+  return ret;
+}
+
+uint64_t heap_read_int64(uint32_t ptr) {
+  uint8_t* heap_base = env_memory_memory.data;
+  uint64_t ret = *((uint64_t*)(heap_base + ptr));
+  return ret;
+}
+
+uint32_t varargs_get() {
+  uint32_t ret = heap_read_int32(varargs_position);
+  varargs_position += 4;
+  return ret;
+}
+
+char* varargs_get_str() {
+  uint32_t ptr = heap_read_int32(varargs_position);
+  uint8_t* heap_base = env_memory_memory.data;
+  // TODO: This doesn't properly handle UTF8.
+  char* ret = (char*) (heap_base + ptr);
+  return ret;
+}
+
+uint64_t varargs_get64() {
+  uint64_t ret = heap_read_int64(varargs_position);
+  varargs_position += 8;
+  return ret;
+}
+
+uint32_t varargs_get_zero() {
+  uint32_t ret = varargs_get();
+  assert(ret == 0);
+  return ret;
+}
+
+// Syscall implementations
+uint32_t env_cfunc____syscall54(uint32_t which, uint32_t varargs) {
+  varargs_position = varargs;
+  // ioctl
+  return 0;
+}
+
+uint32_t env_cfunc____syscall6(uint32_t which, uint32_t varargs) {
+  varargs_position = varargs;
+  // close
+  // Since we're going to be working on either stdout, stderr, or stdin,
+  // it doesn't make a whole lot of sense to close them...
+  return 0;
+}
+
+uint32_t env_cfunc____syscall140(uint32_t which, uint32_t varargs) {
+  varargs_position = varargs;
+  // llseek
+  // I can't see how the JS version of this even works -- SYSCALLS.getStreamFromFD()
+  // and FS.llseek are *both* undefined.
+  // So anyway, I'm gonna see what happens if I no-op this as well. Of course,
+  // we need to perform the necessary varargs side-effects.
+  varargs_get(); // stream
+  varargs_get(); // offset_high
+  varargs_get(); // offset_low
+  varargs_get(); // result
+  varargs_get(); // whence
+  return 0;
+}
+
+uint32_t env_cfunc____syscall146(uint32_t which, uint32_t varargs) {
+  varargs_position = varargs;
+  // writev
+  uint32_t stream = varargs_get();
+  uint32_t iov = varargs_get(); // Base address of iovec array
+  uint32_t iovcnt = varargs_get();
+  uint32_t ret = 0;
+
+  // Again, not doing UTF8 properly here.
+  for (int i = 0; i < iovcnt; i++) {
+    // Starting address
+    // Base pointer. Index i is buffer number, each struct is 8 bytes.
+    uint32_t ptr = heap_read_int32(iov + (i * 8));
+    // Length: second int in the struct
+    uint32_t len = heap_read_int32(iov + (i * 8) + 4);
+    write(stream, (void*) (env_memory_memory.data + ptr), len);
+    ret = ret + len;
+  }
+  return ret;
+}
+
+uint32_t env_cfunc__emscripten_memcpy_big(uint32_t dest,
+    uint32_t src, uint32_t len) {
+  uint8_t* heap_base = env_memory_memory.data;
+  memcpy(heap_base + dest, heap_base + src, len);
+  return dest;
+}
+
+// Aborting and errors
+void err(char* str) {
   puts(str);
 }
 
-void abort(char** str) {
+void rts_abort(char* str) {
   env_global_ABORT = 1;
   env_global_EXITSTATUS = 1;
-  printf("abort: %s", str);
+  printf("abort: %s\n", str);
+}
+
+void env_cfunc_nullFunc_ii(char* x) {
+  err("Null pointer exception (ii)\n");
+  rts_abort(x);
+}
+
+void env_cfunc_nullFunc_iiii(char* x) {
+  err("Null pointer exception (iiii)\n");
+  rts_abort(x);
+}
+
+void env_cfunc____assert_fail(char* condition, char* filename,
+    int line, void* func) {
+  char buf[100];
+  sprintf(buf, "Assertion failed: %s, at %s:%d (%p)\n", condition,
+      filename, line, func);
+  rts_abort(buf);
+}
+
+void env_cfunc___exit(int status) {
+  exit(status);
+}
+
+void env_cfunc__exit(int status) {
+  exit(status);
+}
+
+
+// Wrappers
+int env_cfunc__gettimeofday(uint32_t ptr) {
+  uint8_t* heap_base = env_memory_memory.data;
+  struct timeval time_struct;
+  gettimeofday(&time_struct, NULL);
+  heap_base[ptr] = time_struct.tv_sec;
+  heap_base[ptr + 4] = time_struct.tv_usec;
+  return 0;
 }
 
 // I guess these were needed for pthreads support?
@@ -19,29 +161,25 @@ void env_cfunc____unlock() {
 }
 
 void env_cfunc_abortOnCannotGrowMemory() {
-  abort("Memory is static for now.");
+  rts_abort("Memory is static for now.");
 }
 
 void env_cfunc_enlargeMemory() {
   env_cfunc_abortOnCannotGrowMemory();
 }
 
-int env_cfunc____setErrNo(int value) {
-  // FIXME: This should call XXX_cfunc____errno_location() to
-  // ascertain the error number location, and then write the
-  // error number to the result >>2 in the heap.
-  return value;
-}
-
 uint64_t env_cfunc_getTotalMemory() {
   return env_global_TOTAL_MEMORY;
 }
 
-void env_cfunc_abortStackOverflow(alloc_size) {
+void env_cfunc_abortStackOverflow(uint32_t alloc_size) {
   char buffer[100];
   // TODO: It would be nice to print out the amount the stack overflowed
   // by, but for this, we need "stackSave" which we would have to link...
-  sprintf(buffer, "Stack overflow! Attempted to allocate %d bytes on the stack.");
+  sprintf(buffer,
+      "Stack overflow! Attempted to allocate %d bytes on the stack.",
+      alloc_size);
+  rts_abort(buffer);
 }
 
 void env_init() {
@@ -50,12 +188,14 @@ void env_init() {
     env_global_STACK_BASE + env_global_TOTAL_STACK;
   env_global_STACK_MAX = env_global_STACK_BASE;
   env_global_STATIC_BASE = env_global_GLOBAL_BASE;
-  env_global_STATICTOP = STATIC_BASE + env_global_STATIC_BUMP;
+  env_global_STATICTOP = env_global_STATIC_BASE + env_global_STATIC_BUMP;
   env_global_tempDoublePtr = env_global_STATICTOP;
   env_global_STATICTOP += 16;
 
   // Allocate table and memory
-  wasm_rt_allocate_memory(&env_memory_memory, env_global_TOTAL_MEMORY / WASM_PAGE_SIZE, env_global_TOTAL_MEMORY / WASM_PAGE_SIZE);
+  wasm_rt_allocate_memory(&env_memory_memory,
+      env_global_TOTAL_MEMORY / WASM_PAGE_SIZE,
+      env_global_TOTAL_MEMORY / WASM_PAGE_SIZE);
   wasm_rt_allocate_table(&env_table_table, 1024, -1);
 
 }

--- a/src/rts/emscripten_rts.c
+++ b/src/rts/emscripten_rts.c
@@ -1,0 +1,61 @@
+#include "emscripten_rts.h"
+
+void err(char** str) {
+  puts(str);
+}
+
+void abort(char** str) {
+  env_global_ABORT = 1;
+  env_global_EXITSTATUS = 1;
+  printf("abort: %s", str);
+}
+
+// I guess these were needed for pthreads support?
+// Nothing in our output anyway.
+void env_cfunc____lock() {
+}
+
+void env_cfunc____unlock() {
+}
+
+void env_cfunc_abortOnCannotGrowMemory() {
+  abort("Memory is static for now.");
+}
+
+void env_cfunc_enlargeMemory() {
+  env_cfunc_abortOnCannotGrowMemory();
+}
+
+int env_cfunc____setErrNo(int value) {
+  // FIXME: This should call XXX_cfunc____errno_location() to
+  // ascertain the error number location, and then write the
+  // error number to the result >>2 in the heap.
+  return value;
+}
+
+uint64_t env_cfunc_getTotalMemory() {
+  return env_global_TOTAL_MEMORY;
+}
+
+void env_cfunc_abortStackOverflow(alloc_size) {
+  char buffer[100];
+  // TODO: It would be nice to print out the amount the stack overflowed
+  // by, but for this, we need "stackSave" which we would have to link...
+  sprintf(buffer, "Stack overflow! Attempted to allocate %d bytes on the stack.");
+}
+
+void env_init() {
+  // Initialise stack top / max
+  env_global_STACKTOP =
+    env_global_STACK_BASE + env_global_TOTAL_STACK;
+  env_global_STACK_MAX = env_global_STACK_BASE;
+  env_global_STATIC_BASE = env_global_GLOBAL_BASE;
+  env_global_STATICTOP = STATIC_BASE + env_global_STATIC_BUMP;
+  env_global_tempDoublePtr = env_global_STATICTOP;
+  env_global_STATICTOP += 16;
+
+  // Allocate table and memory
+  wasm_rt_allocate_memory(&env_memory_memory, env_global_TOTAL_MEMORY / WASM_PAGE_SIZE, env_global_TOTAL_MEMORY / WASM_PAGE_SIZE);
+  wasm_rt_allocate_table(&env_table_table, 1024, -1);
+
+}

--- a/src/rts/emscripten_rts.c
+++ b/src/rts/emscripten_rts.c
@@ -55,6 +55,7 @@ uint32_t env_cfunc____syscall54(uint32_t which, uint32_t varargs) {
 
 uint32_t env_cfunc____syscall6(uint32_t which, uint32_t varargs) {
   varargs_position = varargs;
+  varargs_get(); // close
   // close
   // Since we're going to be working on either stdout, stderr, or stdin,
   // it doesn't make a whole lot of sense to close them...
@@ -158,10 +159,10 @@ uint32_t env_cfunc____setErrNo(uint32_t value) {
 // Wrappers
 uint32_t env_cfunc__gettimeofday(uint32_t ptr) {
   uint8_t* heap_base = env_memory_memory.data;
-  struct timeval time_struct;
+    struct timeval time_struct;
   gettimeofday(&time_struct, NULL);
-  heap_base[ptr] = time_struct.tv_sec;
-  heap_base[ptr + 4] = time_struct.tv_usec;
+  *((uint32_t*) (heap_base + ptr)) = (uint32_t) time_struct.tv_sec;
+  *((uint32_t*) (heap_base + ptr + 4)) = (uint32_t) time_struct.tv_usec;
   return 0;
 }
 
@@ -262,6 +263,7 @@ void env_init() {
   // Initialise dynamic base, and save to memory
   env_global_DYNAMIC_BASE = align_memory(env_global_STACK_MAX);
   uint8_t* heap_base = env_memory_memory.data;
-  heap_base[env_global_DYNAMICTOP_PTR] = (uint32_t) env_global_DYNAMIC_BASE;
+  *((uint32_t*) (heap_base + env_global_DYNAMICTOP_PTR)) =
+    (uint32_t) env_global_DYNAMIC_BASE;
   assert(env_global_DYNAMIC_BASE < env_global_TOTAL_MEMORY);
 }

--- a/src/rts/emscripten_rts.h
+++ b/src/rts/emscripten_rts.h
@@ -1,6 +1,19 @@
 #ifndef CMM_OF_WASM_EMSCRIPTEN_RTS
 #define CMM_OF_WASM_EMSCRIPTEN_RTS
 
+#include <sys/time.h>
+#include <sys/uio.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <math.h>
+#include <assert.h>
+#include "wasm-rt.h"
+
+#define WASM_PAGE_SIZE 65535
+
 uint64_t env_global_ABORT = 0;
 uint64_t env_global_EXITSTATUS = 0;
 double env_global_NaN = NAN;
@@ -27,4 +40,13 @@ uint64_t env_global_memoryBase = 0;
 
 wasm_rt_table_t env_table_table;
 wasm_rt_memory_t env_memory_memory;
+
+
+uint32_t env_cfunc____syscall54(uint32_t which, uint32_t varargs);
+uint32_t env_cfunc____syscall6(uint32_t which, uint32_t varargs);
+uint32_t env_cfunc____syscall140(uint32_t which, uint32_t varargs);
+uint32_t env_cfunc____syscall146(uint32_t which, uint32_t varargs);
+uint32_t env_cfunc__emscripten_memcpy_big(uint32_t dest,
+    uint32_t src, uint32_t num);
+
 #endif

--- a/src/rts/emscripten_rts.h
+++ b/src/rts/emscripten_rts.h
@@ -12,41 +12,57 @@
 #include <assert.h>
 #include "wasm-rt.h"
 
-#define WASM_PAGE_SIZE 65535
+#define WASM_PAGE_SIZE 65536
 
-uint64_t env_global_ABORT = 0;
-uint64_t env_global_EXITSTATUS = 0;
-double env_global_NaN = NAN;
-double env_global_Infinity = INFINITY;
+uint64_t env_global_ABORT;
+uint64_t env_global_EXITSTATUS;
+double global_global_NaN;
+double global_global_Infinity;
 
 // Hack: just taking this from PolyBenchC output code at the moment
-uint64_t env_global_TOTAL_STACK = 5242880;
-uint64_t env_global_TOTAL_MEMORY = 16777216;
+uint64_t env_global_TOTAL_STACK;
+uint64_t env_global_TOTAL_MEMORY;
 
-uint64_t env_global_GLOBAL_BASE = 1024;
+uint64_t env_global_GLOBAL_BASE;
 
-uint64_t env_global_STATIC_BASE = 0;
-uint64_t env_global_STATIC_BUMP = 5840;
-uint64_t env_global_STATICTOP = 0;
-uint64_t env_global_STACK_BASE = 0;
-uint64_t env_global_STACKTOP = 0;
-uint64_t env_global_STACK_MAX = 0;
-uint64_t env_global_DYNAMIC_BASE = 0;
-uint64_t env_global_DYNAMICTOP_PTR = 0;
-uint64_t env_global_tempDoublePtr = 0;
+uint64_t env_global_STATIC_BASE;
+uint64_t env_global_STATIC_BUMP;
+uint64_t env_global_STATICTOP;
+uint64_t env_global_STACK_BASE;
+uint64_t env_global_STACKTOP;
+uint64_t env_global_STACK_MAX;
+uint64_t env_global_DYNAMIC_BASE;
+uint64_t env_global_DYNAMICTOP_PTR;
+uint64_t env_global_tempDoublePtr;
 
-uint64_t env_global_tableBase = 0;
-uint64_t env_global_memoryBase = 0;
+uint64_t env_global_tableBase;
+uint64_t env_global_memoryBase;
 
 wasm_rt_table_t env_table_table;
 wasm_rt_memory_t env_memory_memory;
 
-
+void env_cfunc_abort(char* str);
 uint32_t env_cfunc____syscall54(uint32_t which, uint32_t varargs);
 uint32_t env_cfunc____syscall6(uint32_t which, uint32_t varargs);
 uint32_t env_cfunc____syscall140(uint32_t which, uint32_t varargs);
 uint32_t env_cfunc____syscall146(uint32_t which, uint32_t varargs);
 uint32_t env_cfunc__emscripten_memcpy_big(uint32_t dest,
     uint32_t src, uint32_t num);
+
+void env_cfunc_nullFunc_ii(char* x);
+uint32_t env_cfunc____setErrNo(uint32_t value);
+void env_cfunc____assert_fail(char* condition, char* filename,
+    int line, void* func);
+uint32_t env_cfunc__gettimeofday(uint32_t ptr);
+void env_cfunc____lock();
+void env_cfunc____unlock();
+void env_cfunc_abortOnCannotGrowMemory();
+void env_cfunc_enlargeMemory();
+uint32_t env_cfunc_getTotalMemory();
+void env_cfunc_abortStackOverflow(uint32_t alloc_size);
+void env_cfunc___exit(uint32_t status);
+void env_cfunc__exit(uint32_t status);
+
+void env_init();
 
 #endif

--- a/src/rts/emscripten_rts.h
+++ b/src/rts/emscripten_rts.h
@@ -1,0 +1,30 @@
+#ifndef CMM_OF_WASM_EMSCRIPTEN_RTS
+#define CMM_OF_WASM_EMSCRIPTEN_RTS
+
+uint64_t env_global_ABORT = 0;
+uint64_t env_global_EXITSTATUS = 0;
+double env_global_NaN = NAN;
+double env_global_Infinity = INFINITY;
+
+// Hack: just taking this from PolyBenchC output code at the moment
+uint64_t env_global_TOTAL_STACK = 5242880;
+uint64_t env_global_TOTAL_MEMORY = 16777216;
+
+uint64_t env_global_GLOBAL_BASE = 1024;
+
+uint64_t env_global_STATIC_BASE = 0;
+uint64_t env_global_STATIC_BUMP = 5840;
+uint64_t env_global_STATICTOP = 0;
+uint64_t env_global_STACK_BASE = 0;
+uint64_t env_global_STACKTOP = 0;
+uint64_t env_global_STACK_MAX = 0;
+uint64_t env_global_DYNAMIC_BASE = 0;
+uint64_t env_global_DYNAMICTOP_PTR = 0;
+uint64_t env_global_tempDoublePtr = 0;
+
+uint64_t env_global_tableBase = 0;
+uint64_t env_global_memoryBase = 0;
+
+wasm_rt_table_t env_table_table;
+wasm_rt_memory_t env_memory_memory;
+#endif


### PR DESCRIPTION
This PR introduces a minimal RTS to provide the runtime infrastructure expected by applications compiled using Emscripten.

It's hugely incomplete, but can handle memory allocation and provides the symbols needed to get (at least some of, but probably the vast majority of) PolyBenchC to compile.

Fixes #66.